### PR TITLE
Add a simple task queue implementation

### DIFF
--- a/reddit2telegram/task_queue.py
+++ b/reddit2telegram/task_queue.py
@@ -1,0 +1,100 @@
+import logging
+import time
+from concurrent.futures import Executor
+from enum import Enum
+from typing import List, Mapping
+
+import pymongo
+from bson.objectid import ObjectId
+from pymongo.database import Database
+from pymongo.collection import Collection
+
+from supplier import supply
+
+
+COLLECTION = 'tasks'
+
+TASK_SUPPLY = 'supply'
+
+
+logger = logging.getLogger(__name__)
+
+
+class TaskStatus(Enum):
+    NEW = 1
+    IN_PROGRESS = 2
+    SUCCESS = 3
+    FAILED = 4
+
+
+def create_task_dict(task_name: str, args: Mapping):
+    return {
+        'name': task_name,
+        'args': args,
+        'status': TaskStatus.NEW.value,
+        'created_at': time.time(),
+        'updated_at': time.time(),
+    }
+
+
+def submit(mongo_database: Database, task_name: str, args: Mapping):
+    task = create_task_dict()
+    task_id = mongo_database[COLLECTION].insert_one(task)
+    logger.info(f'Submitted task {task_id}')
+
+
+def submit_batch(mongo_database: Database, task_name: str, args_list: List[Mapping]):
+    tasks = map(lambda args: create_task_dict(task_name, args), args_list)
+    result = mongo_database[COLLECTION].insert_many(tasks)
+    logger.info(f"Inserted {len(result.inserted_ids)} tasks")
+
+
+def update_task_status(collection: Collection, id: ObjectId, new_status: TaskStatus):
+    result = collection.update_one({'_id': id}, {
+        '$set': {
+            'status': new_status.value,
+            'updated_at': time.time(),
+        },
+    })
+    logger.info('Modified %d docs', result.modified_count)
+
+
+def select_all_available_tasks(collection: Collection):
+    return list(collection.find({
+        'status': TaskStatus.NEW.value,
+    }, sort=[('created_at', pymongo.ASCENDING)]))
+
+
+def execute_task(collection: Collection, id: ObjectId, name: str, args: Mapping):
+    update_task_status(collection, id, TaskStatus.IN_PROGRESS)
+    try:
+        func = None
+        if name == TASK_SUPPLY:
+            func = supply
+        else:
+            raise Exception(f'Task {name} not found')
+        func(**args)
+        update_task_status(collection, id, TaskStatus.SUCCESS)
+    except Exception as e:
+        logger.exception(f'Task {name} failed with exception')
+        update_task_status(collection, id, TaskStatus.FAILED)
+
+
+def start_consumer(
+    mongo_database: Database,
+    executor: Executor,
+    sleep_interval_seconds: float,
+):
+    running = True
+    collection = mongo_database[COLLECTION]
+    logger.info('Starting consumer %s', executor)
+    while running:
+        try:
+            new_tasks = select_all_available_tasks(collection)
+            logger.info('Found %d new tasks', len(new_tasks))
+            for t in new_tasks:
+                executor.submit(execute_task, collection, t['_id'], t['name'], t['args'])
+            time.sleep(sleep_interval_seconds)
+        except KeyboardInterrupt:
+            logger.info('Stopping consumer')
+            running = False

--- a/reddit2telegram/task_queue_consumer.py
+++ b/reddit2telegram/task_queue_consumer.py
@@ -1,0 +1,41 @@
+import logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+)
+
+import concurrent.futures
+from multiprocessing import cpu_count
+
+import pymongo
+import yaml
+
+import task_queue
+
+
+def _create_thread_pool(config) -> concurrent.futures.Executor:
+    pool_config = config.get('pool', {})
+    pool_class = pool_config.get('class', 'ProcessPoolExecutor')
+    size = pool_config.get('size', cpu_count())
+    if pool_class == 'ThreadPoolExecutor':
+        return concurrent.futures.ThreadPoolExecutor(size)
+    elif pool_class == 'ProcessPoolExecutor':
+        return concurrent.futures.ProcessPoolExecutor(size)
+    else:
+        raise ValueError(f"Invalid pool class name: {pool_class}")
+
+
+def main(config_filename):
+    with open(config_filename) as config_file:
+        config = yaml.safe_load(config_file.read())
+    db = pymongo.MongoClient(host=config['db']['host'])[config['db']['name']]
+    executor = _create_thread_pool(config)
+    task_queue.start_consumer(db, executor, 5)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='configs/prod.yml')
+    args = parser.parse_args()
+    main(args.config)

--- a/reddit2telegram/task_queue_cron_app.py
+++ b/reddit2telegram/task_queue_cron_app.py
@@ -1,0 +1,54 @@
+#encoding:utf-8
+import logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+)
+
+import datetime
+import csv
+import random
+
+import pymongo
+import yaml
+from croniter import croniter
+
+import task_queue
+
+
+logger = logging.getLogger(__name__)
+
+
+def read_own_cron(own_cron_filename, config):
+    with open(own_cron_filename) as tsv_file:
+        tsv_reader = csv.DictReader(tsv_file, delimiter='\t')
+        list_of_processes_to_start = list()
+        for row in tsv_reader:
+            now = datetime.datetime.now()
+            cron = croniter(row['MASK'])
+            prev_run = cron.get_prev(datetime.datetime)
+            diff = now - prev_run
+            diff_seconds = diff.total_seconds()
+            if 0.0 <= diff_seconds and diff_seconds <= 59.9:
+                submodule_name = row['submodule_name'].split('\t')[0]
+                list_of_processes_to_start.append(submodule_name)
+    random.shuffle(list_of_processes_to_start)
+    db = pymongo.MongoClient(host=config['db']['host'])[config['db']['name']]
+    task_queue.submit_batch(db, task_queue.TASK_SUPPLY, [{
+        'submodule_name': submodule_name,
+        'config': config,
+    } for submodule_name in list_of_processes_to_start])
+
+
+def main(config_filename):
+    with open(config_filename) as config_file:
+        config = yaml.safe_load(config_file.read())
+        read_own_cron(config['cron_file'], config)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='configs/prod.yml')
+    args = parser.parse_args()
+    main(args.config)

--- a/reddit2telegram/utils/setup.py
+++ b/reddit2telegram/utils/setup.py
@@ -21,7 +21,7 @@ def create_view_with_first_dates(config_filename=None):
     db = pymongo.MongoClient(host=config['db']['host'])[config['db']['name']]
     if VIEW_NAME not in db.collection_names():
         db.command('create', VIEW_NAME,
-            viewOn='urls', 
+            viewOn='urls',
             pipeline=[
                 {
                     '$group':
@@ -55,6 +55,8 @@ def ensure_index(config_filename=None):
     channels = db['channels']
     channels.create_index([('channel', pymongo.ASCENDING)])
     channels.create_index([('submodule', pymongo.ASCENDING)])
+    tasks = db['tasks']
+    tasks.create_index([('status', pymongo.ASCENDING), ('created_at', pymongo.ASCENDING)])
     print('ENSURE INDEX END.')
 
 


### PR DESCRIPTION
# PR Details
Adding a task queue based implementation that might optimise memory consumption.

## Setup
- Run `utils/setup.py` to create a DB index
- Modify cron task to run `task_queue_cron_app.py`
- Run `task_queue_consumer.py` as a daemon 

After that tasks should be submitted to the MongoDB queue and consumed by the pool in daemon's memory. 


