### PR TITLE
Mark tasks as scheduled when they are submitted to the executor pool

### DIFF
--- a/reddit2telegram/task_queue.py
+++ b/reddit2telegram/task_queue.py
@@ -26,6 +26,7 @@ class TaskStatus(Enum):
     IN_PROGRESS = 2
     SUCCESS = 3
     FAILED = 4
+    SCHEDULED = 5
 
 
 def create_task_dict(task_name: str, args: Mapping):
@@ -100,6 +101,7 @@ def start_consumer(
                 if task_age < 25 * 60:
                     # If task was create less than 25 mins ago, then ok.
                     executor.submit(execute_task, collection, t['_id'], t['name'], t['args'])
+                    update_task_status(collection, t['_id'], TaskStatus.SCHEDULED)
                 else:
                     # If the task is older than 25 mins, just skip.
                     # logger.info(f'Too old task → {round(task_age / 60)} mins.')


### PR DESCRIPTION
# PR Details

This PR tries to address the following condition:
- Task is submitted to the database 
- Task is queried from the database and is submitted to the pool, but the pool already has a big queue of pending tasks
- When consumer starts again, it queries the same task again because its database status hasn't changed yet
- Consumer submits the task once again