### PR TITLE
requirements.txt: Pin `python-telegram-bot` to v13.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 praw
-python-telegram-bot
+python-telegram-bot==13.15
 yandex.translate
 pymongo==3.12
 requests


### PR DESCRIPTION
## PR Details
Python-telegram-bot library have been updated to v20.1
Newer version gave an error `ImportError: cannot import name 'ParseMode' from 'telegram'`

