### PR TITLE
Fix audio not being downloaded

### DIFF
--- a/reddit2telegram/utils/__init__.py
+++ b/reddit2telegram/utils/__init__.py
@@ -21,7 +21,6 @@ from pymongo.collection import ReturnDocument
 import telegram
 from telegram.error import TelegramError, BadRequest
 from telegram import ParseMode
-import m3u8
 
 from utils.tech import short_sleep, long_sleep
 

--- a/reddit2telegram/utils/__init__.py
+++ b/reddit2telegram/utils/__init__.py
@@ -458,10 +458,7 @@ class Reddit2TelegramSender(object):
 
         try:
             # Download audio
-            audio_playlist_url = url[:url.rfind('/')] + '/HLS_AUDIO_160_K.m3u8'
-            audio_playlist = m3u8.load(audio_playlist_url)
-            segment_0 = audio_playlist.segments[0]
-            audio_url = segment_0.absolute_uri
+            audio_url = url[:url.rfind('/')] + '/DASH_AUDIO_128.mp4'
             audio_filename = filename + '.aac'
             if not download_file(audio_url, audio_filename):
                 return SupplyResult.DO_NOT_WANT_THIS_SUBMISSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ requests
 imgurpython
 raven
 croniter
-m3u8


### PR DESCRIPTION
# PR Details
The previous solution for downloading audio stopped working.
New solution is even easier: we now don't need m3u8, the code for getting link to audio
```python
audio_url = url[:url.rfind('/')] + '/DASH_AUDIO_128.mp4'
```
I haven't tested the whole thing though ¯\_(ツ)_/¯ My guess is that if the codec hasn't changed (aac) + I've tried it on [one video](https://v.redd.it/mxzo6u6z0imb1/DASH_AUDIO_128.mp4) therefore it should work